### PR TITLE
attempt to update thor

### DIFF
--- a/approvals.gemspec
+++ b/approvals.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rspec', '~> 3.1'
   s.add_development_dependency 'json', '~> 1.8'
-  s.add_dependency 'thor', '~> 0.18'
+  s.add_dependency 'thor', '~> 1.0'
   s.add_dependency 'nokogiri', '~> 1.6'
 end


### PR DESCRIPTION
Because the newest bundle-audit needs a newer version of thor
and because r101-api depends on this AND bundle-audit
we run into conflicts.

This is an attempt to resolve that conflict while hopefully not breaking things.

This is needed to allow remind101/r101-api#16644 to resolve without conflicts.